### PR TITLE
define THRUST_IGNORE_CUB_VERSION_CHECK

### DIFF
--- a/svox_t/csrc/include/common.cuh
+++ b/svox_t/csrc/include/common.cuh
@@ -26,7 +26,7 @@
  */
 
 #pragma once
-
+#define THRUST_IGNORE_CUB_VERSION_CHECK
 #include <torch/extension.h>
 #include <cuda.h>
 #include <cuda_runtime.h>


### PR DESCRIPTION
fix error : #error The version of CUB in your include path is not compatible with this release of Thrust. CUB is now included in the CUDA Toolkit, so you no longer need to use your own checkout of CUB. Define THRUST_IGNORE_CUB_VERSION_CHECK to ignore this.
